### PR TITLE
fix: error on text-only post

### DIFF
--- a/pkgs/app/src/lib/parseEmbedDescription.ts
+++ b/pkgs/app/src/lib/parseEmbedDescription.ts
@@ -8,11 +8,11 @@ export function parseEmbedDescription(post: AppBskyFeedDefs.PostView): string {
       checkType('app.bsky.embed.recordWithMedia#view', post.embed));
 
   let embed;
-  if(isQuote){
+  if (isQuote) {
     // @ts-expect-error
     embed = post.embed.record?.record ?? post.embed.record;
   }
-  
+
   return isQuote
     ? // @ts-expect-error
       `${post.record.text}\n\nQuoting @${embed.author.handle}\n➥${indent(embed.value.text, 2)}`

--- a/pkgs/app/src/lib/parseEmbedDescription.ts
+++ b/pkgs/app/src/lib/parseEmbedDescription.ts
@@ -7,9 +7,12 @@ export function parseEmbedDescription(post: AppBskyFeedDefs.PostView): string {
     (checkType('app.bsky.embed.record#view', post.embed) ||
       checkType('app.bsky.embed.recordWithMedia#view', post.embed));
 
-  // @ts-expect-error
-  const embed = post.embed.record?.record ?? post.embed.record;
-
+  let embed;
+  if(isQuote){
+    // @ts-expect-error
+    embed = post.embed.record?.record ?? post.embed.record;
+  }
+  
   return isQuote
     ? // @ts-expect-error
       `${post.record.text}\n\nQuoting @${embed.author.handle}\n➥${indent(embed.value.text, 2)}`


### PR DESCRIPTION
fixes #16

post.embed is not part of the object when it is a text only post so this is tossing an error. This was already only using embed if isQuote was true so just use isQuote to decide if we even look for the embed value.