### PR TITLE
fix: spoilers break embedding

### DIFF
--- a/pkgs/app/src/routes/getPost.tsx
+++ b/pkgs/app/src/routes/getPost.tsx
@@ -29,7 +29,8 @@ export const getPost: Handler<
   Env,
   '/profile/:user/post/:post' | '/https://bsky.app/profile/:user/post/:post'
 > = async (c) => {
-  const { user, post } = c.req.param();
+  let { user, post } = c.req.param();
+  post = post.replaceAll('|', '');
   const isDirect = c.req.query('direct');
 
   const agent = c.get('Agent');

--- a/pkgs/app/src/routes/getProfile.tsx
+++ b/pkgs/app/src/routes/getProfile.tsx
@@ -7,7 +7,8 @@ export const getProfile: Handler<
   Env,
   '/profile/:user' | '/https://bsky.app/profile/:user'
 > = async (c) => {
-  const { user } = c.req.param();
+  let { user } = c.req.param();
+  user = user.replaceAll('|', '');
   const agent = c.get('Agent');
   try {
     var { data } = await fetchProfile(agent, { user });


### PR DESCRIPTION
fixes #17 

Discord is very silly and is sending the '||' from the end-spoiler tag on the end of the url when creating the spoiler embeds. | is not a valid character in post or user params so simply doing a replaceAll fixes it. There might be a more elegant way to handle this at the top level but I was lazy and this was a quick easy fixx in 2 places. Really discord needs to fix this.