### PR TITLE
Fix canonical URL + add og:url

### DIFF
--- a/pkgs/app/src/components/Layout.tsx
+++ b/pkgs/app/src/components/Layout.tsx
@@ -15,11 +15,12 @@ export const Layout = ({ url, children }: LayoutProps) => {
     <html>
       <head>
         <link rel="canonical" href="${redirectUrl}"/>
+        <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
         <meta property="og:url" content="${redirectUrl}"/>
         <meta name="theme-color" content="#0085ff"/>
         <meta property="og:site_name" content="VixBluesky"/>
         ${children}
-        <meta http-equiv="refresh" content="0;url=${redirectUrl}"/>
+        <meta http-equiv="refresh" content="0;url=${redirectUrl}" />
       </head>
     </html>
   `

--- a/pkgs/app/src/components/Layout.tsx
+++ b/pkgs/app/src/components/Layout.tsx
@@ -14,13 +14,12 @@ export const Layout = ({ url, children }: LayoutProps) => {
     <!doctype html>
     <html>
       <head>
-        <link rel="canonical" href="${url.substring(1)}" />
-        <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
-        <meta content="#0085ff" name="theme-color" />
-        <meta property="og:site_name" content="VixBluesky" />
-
+        <link rel="canonical" href="${redirectUrl}"/>
+        <meta property="og:url" content="${redirectUrl}"/>
+        <meta name="theme-color" content="#0085ff"/>
+        <meta property="og:site_name" content="VixBluesky"/>
         ${children}
-        <meta http-equiv="refresh" content="0;url=${redirectUrl}" />
+        <meta http-equiv="refresh" content="0;url=${redirectUrl}"/>
       </head>
     </html>
   `


### PR DESCRIPTION
Quick fix for #35

Note: hono sets HTTP Header `Content-Type` to `text/html; charset=UTF-8` when you use `c.html()`, so you shouldn't need that specific meta tag